### PR TITLE
Add ProxyOrb to proxy resources list

### DIFF
--- a/Dump.md
+++ b/Dump.md
@@ -35,6 +35,7 @@ sidebar_label: Dump
 - [k8s-usenet](https://github.com/aldoborrero/k8s-usenet) - Helm (Kubernetes based) - collection of charts related to different Usenet services (sabnzbd, radarr, sonarr etc).
 - [Unblocked](https://unblockit.pw/) - A Proxy site for accessing your favorite blocked sites.
   - [unblocked-pw.github.io](https://unblocked-pw.github.io/) - Mirror on Github.
+- [ProxyOrb](https://proxyorb.com/) - Free site proxy and online proxy browser - secure, anonymous, and instant access to any blocked website.
 
 ## Piracy News & Forums
 


### PR DESCRIPTION
This PR adds a new entry introducing [ProxyOrb: Webiste Unblocker](https://proxyorb.com/) — a free site proxy and online proxy browser designed for secure, anonymous, and instant access to blocked or restricted websites.